### PR TITLE
add failing test for listenFunc

### DIFF
--- a/telnet/telnet_test.go
+++ b/telnet/telnet_test.go
@@ -7,6 +7,20 @@ import (
 	"time"
 )
 
+func Test_ListenFunc(t *testing.T) {
+	tp := newTelnetProcessor()
+	runCount := 0
+	tp.listenFunc = func(TelnetCode, []byte) {
+		runCount += 1
+	}
+	header := BuildCommand(WILL, 25, IAC, WILL, ATCP, IAC, WILL, GMCP, IAC, WILL, CMP2, IAC, DO, TT, 24)
+	header = append(header, []byte("Rapture Runtime Environment v2.4.1")...)
+	tp.addBytes(header)
+	if runCount != 5 {
+		t.Fatalf("listenFunc did not trigger correctly on sample Achaea header, got %d times instead of %d", runCount, 5)
+	}
+}
+
 type fakeConn struct {
 	data []byte
 }


### PR DESCRIPTION
Hi again! Sorry. I'm trying to solve this myself but this seems like the most complicated operation in this package, so instead I made a failing test to illustrate the behavior I'm expecting (with a real world example to boot!).

I made this as minimal as I could manage, it only involves the `telnetProcessor` and shoving some dummy data into it, but since `listenFunc` is only ever run as part of `addByte` this makes sense to me. Please let me know if I'm off base here: but the real world issue I'm experiencing is in fact that `listenFunc` never seems to trigger at all when I connect to Achaea.

I'm not 100% sure if the number should be 5 (easy enough to change if not), but the result I get is 0, which is most certainly not right.